### PR TITLE
Adjust tab.hoverBackground to #363636

### DIFF
--- a/src/adwaita_ui_colors.py
+++ b/src/adwaita_ui_colors.py
@@ -18,7 +18,7 @@ def get_adwaita_ui_colors(theme_type, colorful_status_bar=False):
         'tab.inactiveBackground':               '#262626' if dark else '#e1e1e1',
         'editorGroupHeader.tabsBackground':     '#262626' if dark else '#e1e1e1',
         'breadcrumb.background':                '#262626' if dark else '#e1e1e1',
-        'tab.hoverBackground':                  '#2d2d2d' if dark else '#dcdcdc',
+        'tab.hoverBackground':                  '#363636' if dark else '#dcdcdc',
         # 'tab.activeForeground':               '#ffffff'
         # 'tab.inactiveForeground':             '#cccccc'
 

--- a/themes/adwaita-dark-colorful-status-bar.json
+++ b/themes/adwaita-dark-colorful-status-bar.json
@@ -10,7 +10,7 @@
     "tab.inactiveBackground": "#262626",
     "editorGroupHeader.tabsBackground": "#262626",
     "breadcrumb.background": "#262626",
-    "tab.hoverBackground": "#2d2d2d",
+    "tab.hoverBackground": "#363636",
     "panel.background": "#242424",
     "sideBar.background": "#242424",
     "statusBar.background": "#1C71D8",

--- a/themes/adwaita-dark-default-syntax-highlighting-colorful-status-bar.json
+++ b/themes/adwaita-dark-default-syntax-highlighting-colorful-status-bar.json
@@ -10,7 +10,7 @@
     "tab.inactiveBackground": "#262626",
     "editorGroupHeader.tabsBackground": "#262626",
     "breadcrumb.background": "#262626",
-    "tab.hoverBackground": "#2d2d2d",
+    "tab.hoverBackground": "#363636",
     "panel.background": "#242424",
     "sideBar.background": "#242424",
     "statusBar.background": "#1C71D8",

--- a/themes/adwaita-dark-default-syntax-highlighting.json
+++ b/themes/adwaita-dark-default-syntax-highlighting.json
@@ -10,7 +10,7 @@
     "tab.inactiveBackground": "#262626",
     "editorGroupHeader.tabsBackground": "#262626",
     "breadcrumb.background": "#262626",
-    "tab.hoverBackground": "#2d2d2d",
+    "tab.hoverBackground": "#363636",
     "panel.background": "#242424",
     "sideBar.background": "#242424",
     "statusBar.background": "#242424",

--- a/themes/adwaita-dark.json
+++ b/themes/adwaita-dark.json
@@ -10,7 +10,7 @@
     "tab.inactiveBackground": "#262626",
     "editorGroupHeader.tabsBackground": "#262626",
     "breadcrumb.background": "#262626",
-    "tab.hoverBackground": "#2d2d2d",
+    "tab.hoverBackground": "#363636",
     "panel.background": "#242424",
     "sideBar.background": "#242424",
     "statusBar.background": "#242424",


### PR DESCRIPTION
Libadwaita dark actually lightens the background color when elements are hovered

![Screenshot from 2022-04-14 18-33-51](https://user-images.githubusercontent.com/91024200/163488879-514134d0-72d0-4847-9fd8-2b79c30ca8f9.png)

![Screenshot from 2022-04-14 18-34-36](https://user-images.githubusercontent.com/91024200/163488892-f18ef50a-3d04-4271-ac46-45089a5383d9.png)

Signed-off-by: wroy <wroy@pm.me>