### PR TITLE
Add border above breadcrumbs bar

### DIFF
--- a/src/adwaita_ui_colors.py
+++ b/src/adwaita_ui_colors.py
@@ -34,6 +34,7 @@ def get_adwaita_ui_colors(theme_type, colorful_status_bar=False):
         'editorBracketMatch.border':            '#454545' if dark else '#cfcfcf',
         'editorGroup.border':                   '#454545' if dark else '#cfcfcf',
         'editorGroupHeader.border':             '#454545' if dark else '#cfcfcf',
+        'editorGroupHeader.tabsBorder':         '#454545' if dark else '#cfcfcf',
         'panel.border':                         '#454545' if dark else '#cfcfcf',
         'panelSectionHeader.border':            '#454545' if dark else '#cfcfcf',
         'sideBar.border':                       '#454545' if dark else '#cfcfcf',

--- a/themes/adwaita-dark-colorful-status-bar.json
+++ b/themes/adwaita-dark-colorful-status-bar.json
@@ -22,6 +22,7 @@
     "editorBracketMatch.border": "#454545",
     "editorGroup.border": "#454545",
     "editorGroupHeader.border": "#454545",
+    "editorGroupHeader.tabsBorder": "#454545",
     "panel.border": "#454545",
     "panelSectionHeader.border": "#454545",
     "sideBar.border": "#454545",

--- a/themes/adwaita-dark-default-syntax-highlighting-colorful-status-bar.json
+++ b/themes/adwaita-dark-default-syntax-highlighting-colorful-status-bar.json
@@ -22,6 +22,7 @@
     "editorBracketMatch.border": "#454545",
     "editorGroup.border": "#454545",
     "editorGroupHeader.border": "#454545",
+    "editorGroupHeader.tabsBorder": "#454545",
     "panel.border": "#454545",
     "panelSectionHeader.border": "#454545",
     "sideBar.border": "#454545",

--- a/themes/adwaita-dark-default-syntax-highlighting.json
+++ b/themes/adwaita-dark-default-syntax-highlighting.json
@@ -22,6 +22,7 @@
     "editorBracketMatch.border": "#454545",
     "editorGroup.border": "#454545",
     "editorGroupHeader.border": "#454545",
+    "editorGroupHeader.tabsBorder": "#454545",
     "panel.border": "#454545",
     "panelSectionHeader.border": "#454545",
     "sideBar.border": "#454545",

--- a/themes/adwaita-dark.json
+++ b/themes/adwaita-dark.json
@@ -22,6 +22,7 @@
     "editorBracketMatch.border": "#454545",
     "editorGroup.border": "#454545",
     "editorGroupHeader.border": "#454545",
+    "editorGroupHeader.tabsBorder": "#454545",
     "panel.border": "#454545",
     "panelSectionHeader.border": "#454545",
     "sideBar.border": "#454545",

--- a/themes/adwaita-light-colorful-status-bar.json
+++ b/themes/adwaita-light-colorful-status-bar.json
@@ -22,6 +22,7 @@
     "editorBracketMatch.border": "#cfcfcf",
     "editorGroup.border": "#cfcfcf",
     "editorGroupHeader.border": "#cfcfcf",
+    "editorGroupHeader.tabsBorder": "#cfcfcf",
     "panel.border": "#cfcfcf",
     "panelSectionHeader.border": "#cfcfcf",
     "sideBar.border": "#cfcfcf",

--- a/themes/adwaita-light-default-syntax-highlighting-colorful-status-bar.json
+++ b/themes/adwaita-light-default-syntax-highlighting-colorful-status-bar.json
@@ -22,6 +22,7 @@
     "editorBracketMatch.border": "#cfcfcf",
     "editorGroup.border": "#cfcfcf",
     "editorGroupHeader.border": "#cfcfcf",
+    "editorGroupHeader.tabsBorder": "#cfcfcf",
     "panel.border": "#cfcfcf",
     "panelSectionHeader.border": "#cfcfcf",
     "sideBar.border": "#cfcfcf",

--- a/themes/adwaita-light-default-syntax-highlighting.json
+++ b/themes/adwaita-light-default-syntax-highlighting.json
@@ -22,6 +22,7 @@
     "editorBracketMatch.border": "#cfcfcf",
     "editorGroup.border": "#cfcfcf",
     "editorGroupHeader.border": "#cfcfcf",
+    "editorGroupHeader.tabsBorder": "#cfcfcf",
     "panel.border": "#cfcfcf",
     "panelSectionHeader.border": "#cfcfcf",
     "sideBar.border": "#cfcfcf",

--- a/themes/adwaita-light.json
+++ b/themes/adwaita-light.json
@@ -22,6 +22,7 @@
     "editorBracketMatch.border": "#cfcfcf",
     "editorGroup.border": "#cfcfcf",
     "editorGroupHeader.border": "#cfcfcf",
+    "editorGroupHeader.tabsBorder": "#cfcfcf",
     "panel.border": "#cfcfcf",
     "panelSectionHeader.border": "#cfcfcf",
     "sideBar.border": "#cfcfcf",


### PR DESCRIPTION
Hi! Thanks for the great theme. I like to keep my breadcrumbs bar enabled, so I added a matching border above and I think it makes the tab list much easier to scan. This new property has no effect when breadcrumbs are disabled.

![image](https://user-images.githubusercontent.com/4993980/170848063-29bb4dde-56ee-4f7d-821d-8c64ccad3611.png)
