### PR TITLE
Suggest color scheme autodetection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Open the Command Palette and find "Open Settings (JSON)". Here are the recommend
 "workbench.preferredLightColorTheme": "Adwaita Light",
 "window.titleBarStyle": "native",
 "window.menuBarVisibility": "toggle", // Menu bar will be hidden until you press Alt
+"window.autoDetectColorScheme": true,
 "window.title": "${rootPath}${separator}Code",
 "breadcrumbs.enabled": false,
 "editor.renderLineHighlight": "none",


### PR DESCRIPTION
VSCode implements a setting to auto-detect the color scheme. It may be needed to ensure VSCode keeps up with you if you regularly switch between light and dark mode.